### PR TITLE
Allow overwriting compiler flags from the command line

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,15 @@
+CXXFLAGS?=-03
+CXX?=g++
+LDFLAGS?=-lm -lgsl -lgslcblas -lboost_iostreams -lz
 main: main.o controller.o logistic.o 
-	g++  -O3 main.o controller.o logistic.o  -lm -lgsl -lgslcblas -lboost_iostreams -lz  -o ../../../inst/torus 
+	$(CXX)  $(CXXFLAGS) main.o controller.o logistic.o  $(LDFLAGS)  -o ../../../inst/torus 
 static: main.o controller.o logistic.o
-	g++  -O3 main.o controller.o logistic.o  -lm -lgsl -lgslcblas -lboost_iostreams -lz -static -o torus.static
+	$(CXX) $(CXXFLAGS) main.o controller.o logistic.o  $(LDFLAGS) -static -o torus.static
 main.o: main.cc 
-	g++ -c  main.cc	
+	$(CXX) -c  main.cc	
 controller.o: controller.cc classdef.h
-	g++    -c  controller.cc 
+	$(CXX) -c  controller.cc 
 logistic.o: logistic.cc logistic.h
-	g++ -c logistic.cc -fpermissive
+	$(CXX) -c logistic.cc -fpermissive
 clean:
 	rm *.o torus	


### PR DESCRIPTION
If you use this syntax, users can change from the defaults very easily:
`CXX=clang++ make`
or to debug:
`CXXFLAGS=-0g make`